### PR TITLE
Add a poor man's version of timeout for Windows

### DIFF
--- a/src/Timing.v
+++ b/src/Timing.v
@@ -1,1 +1,8 @@
 Declare ML Module "timing_plugin".
+
+Tactic Notation "poor_mans_timeout" int_or_var(n) tactic(tac) :=
+  reset_timer "__poor_mans_timeout__";
+  start_timer "__poor_mans_timeout__";
+  tac;
+  stop_timer "__poor_mans_timeout__";
+  fail_if_timer_greater_than "__poor_mans_timeout__" n "Timeout!".

--- a/src/timing_plugin.ml4
+++ b/src/timing_plugin.ml4
@@ -1,69 +1,83 @@
 (*i camlp4deps: "parsing/grammar.cma" i*)
 (*i camlp4use: "pa_extend.cmp" i*)
 
+(* For [ArgArg] and [ArgVar] *)
+open Glob_term
+(* For [anomaly] *)
+open Util
+
 module Section = struct
   let current () = Unix.gettimeofday ();;
 
-  module Timer = struct 
+  module Timer = struct
 
     type t =
 	{
-	  stack : float Stack.t ; 
+	  stack : float Stack.t ;
 	  mutable total : float;
-	  mutable number : int; 
+	  mutable number : int;
 	  mutable mean : float;
 	  mutable m2 : float
 	}
-	  
-	  
+
+
     (** operations on timers *)
-    let start (r : t) = 
+    let start (r : t) =
       Stack.push (current ()) r.stack
-	  	  
-    let stop (r : t) = 
-      try 
-	let t = Stack.pop r.stack in 
-	let x = current () -. t in 
-	r.total <- r.total +. x; 
-	r.number <- r.number + 1; 
-	let delta = x -. r.mean in 
-	r.mean <- r.mean +. (delta /. float r.number); 
+
+    let stop (r : t) =
+      try
+	let t = Stack.pop r.stack in
+	let x = current () -. t in
+	r.total <- r.total +. x;
+	r.number <- r.number + 1;
+	let delta = x -. r.mean in
+	r.mean <- r.mean +. (delta /. float r.number);
 	r.m2 <- r.m2 +. delta *. ( x -. r.mean)
-      with 
+      with
 	| Stack.Empty -> () 			(* warning *)
-	 
+
     let zero () =
       {stack = Stack.create (); total = 0. ; number = 0; mean = 0.; m2 = 0.}
+
+    let get (r : t) : float = r.mean
   end
-    
+
   let state = Hashtbl.create 17;;
 
-  (** operations on the mutable global state  *)	  
+  (** operations on the mutable global state  *)
 
-  type key = string 
+  type key = string
   let print_key fmt k = Format.fprintf fmt "%10s" k
   (** [run n] starts the timer [n], and create it if needed *)
   let start (n: key) =
-    let r = 
-      try Hashtbl.find state n 
-      with 
-	| Not_found -> 
-	  let r =  Timer.zero () in 
+    let r =
+      try Hashtbl.find state n
+      with
+	| Not_found ->
+	  let r =  Timer.zero () in
 	  Hashtbl.add state n r;
 	  r
     in
     Timer.start r
 
   (** [stop n] stop the timer [n] *)
-  let stop (n : key) = 
-    try 
-      let r = Hashtbl.find state n in 
+  let stop (n : key) =
+    try
+      let r = Hashtbl.find state n in
       Timer.stop r
-    with 
+    with
       | Not_found -> ()
-	
+
+  let get (n : key) : float =
+    try
+      let r = Hashtbl.find state n in
+      Timer.get r
+    with
+      | Not_found -> Pervasives.float_of_int 0
+
   (** [reset n] sets back a given timer to zero *)
-  let reset (n : key) = 
+  let reset (n : key) =
     Hashtbl.replace state n (Timer.zero ())
 
   (** [clear] reset all timers *)
@@ -72,29 +86,34 @@ module Section = struct
 
   let print fmt () =
     let elements = Hashtbl.fold (fun key elt acc -> (key, elt) :: acc) state [] in
-    let elements = List.sort (Pervasives.compare) elements in 
+    let elements = List.sort (Pervasives.compare) elements in
     List.iter
-      (fun (key,timer) -> 
-	if timer.Timer.number <> 0 
-	then 
-	  begin 
-	    Format.fprintf fmt "%a:\t(total:%f, mean:%f, runs:%i, sigma2:%f)\n" 
-	      print_key key 
+      (fun (key,timer) ->
+	if timer.Timer.number <> 0
+	then
+	  begin
+	    Format.fprintf fmt "%a:\t(total:%f, mean:%f, runs:%i, sigma2:%f)\n"
+	      print_key key
 	      timer.Timer.total
 	      timer.Timer.mean
 	      timer.Timer.number
-	      (timer.Timer.m2 /. (float timer.Timer.number))	  
+	      (timer.Timer.m2 /. (float timer.Timer.number))
 	  end;
 	  )
       elements
-end  
-  
+end
+
+(* [out_arg] stolen from micromega *)
+let out_arg = function
+  | ArgVar _ -> anomaly "Unevaluated or_var variable"
+  | ArgArg x -> x
+
 let _=Mltop.add_known_module "Timing_plugin"
 
 let pp_print () =
-  let buf = Buffer.create 4 in 
-  let fmt = Format.formatter_of_buffer buf in 
-  let _ = (Format.fprintf fmt "%a\n%!" Section.print ()) in 
+  let buf = Buffer.create 4 in
+  let fmt = Format.formatter_of_buffer buf in
+  let _ = (Format.fprintf fmt "%a\n%!" Section.print ()) in
   (Buffer.contents buf)
 
 let _ = Pp.msgnl (Pp.str "Loading the Timing Profiler")
@@ -103,38 +122,47 @@ open Tacexpr
 open Tacinterp
 
 TACTIC EXTEND start_timer
-  | ["start_timer" string(n)] -> 
+  | ["start_timer" string(n)] ->
     [
-      fun gl -> 
-	Section.start n; 
+      fun gl ->
+	Section.start n;
 	Tacticals.tclIDTAC gl]
 END;;
 
 TACTIC EXTEND stop_timer
-  | ["stop_timer" string(n)] -> 
-    [fun gl -> 
+  | ["stop_timer" string(n)] ->
+    [fun gl ->
       Section.stop n;
       Tacticals.tclIDTAC gl]
 END;;
 
 TACTIC EXTEND reset_timer
-  | ["reset_timer" string(n)] -> 
+  | ["reset_timer" string(n)] ->
     [fun gl -> Section.reset n; Tacticals.tclIDTAC gl]
 END;;
 
 TACTIC EXTEND print_current_time
-  | ["print_current_time"] -> 
+  | ["print_current_time"] ->
     [fun gl -> Pp.msgnl (Pp.str (Format.sprintf "Current time: %f\n%!" (Section.current()))); Tacticals.tclIDTAC gl]
 END;;
 
+TACTIC EXTEND fail_if_timer_greater_than
+  | ["fail_if_timer_greater_than" string(n) int_or_var(max_time) string(msg)  ] ->
+    [
+      fun gl ->
+	if Pervasives.compare (Section.get n) (Pervasives.float_of_int (out_arg max_time)) <= 0
+	then Tacticals.tclIDTAC gl
+	else Tacticals.tclFAIL 0 (Pp.str msg) gl
+    ]
+END;;
 
 TACTIC EXTEND time_tactic
-  | ["time" string(n) tactic(t)] -> 
+  | ["time" string(n) tactic(t)] ->
     [
-      let tac =  Tacinterp.eval_tactic t in 
-      fun gl -> 
+      let tac =  Tacinterp.eval_tactic t in
+      fun gl ->
 	Section.start n;
-	let res = tac gl in 
+	let res = tac gl in
 	Section.stop n; res
     ]
 END;;
@@ -148,4 +176,3 @@ VERNAC COMMAND EXTEND ClearTimingProfile
  ["Clear" "Timing" "Profile"] ->
    [ Section.clear () ]
 END;;
-

--- a/test-suite/example.v
+++ b/test-suite/example.v
@@ -1,8 +1,7 @@
-Require Import String. 
-Add Rec LoadPath "../src/" as Timing.  
-Add ML Path "../src/". 
-Declare ML Module "timing_plugin". 
-             
+Require Import String.
+Add LoadPath "../src/" as Timing.
+Require Import Timing.
+
 Ltac count_ltac n m :=
   match n with
     | 0 => m
@@ -11,28 +10,45 @@ Ltac count_ltac n m :=
 Ltac test :=
   start_timer "my_test";
   let x := fresh in let a := count_ltac 100 100 in set (x := a);
-  stop_timer "my_test". 
+  stop_timer "my_test".
 
 Goal True.
-  Clear Timing Profile. 
+  Clear Timing Profile.
 
-  start_timer "global". 
-  Print Timing Profile. 
-  test. 
-  Print Timing Profile. 
-  do 3 test. 
-  Print Timing Profile. 
-  do 3 test. 
-  Print Timing Profile. 
-  do 10 test. 
-  Print Timing Profile. 
-  stop_timer "global". 
-  Print Timing Profile. 
-  Clear Timing Profile. 
+  start_timer "global".
+  Print Timing Profile.
+  test.
+  Print Timing Profile.
+  do 3 test.
+  Print Timing Profile.
+  do 3 test.
+  Print Timing Profile.
+  do 10 test.
+  Print Timing Profile.
+  stop_timer "global".
+  Print Timing Profile.
+  Clear Timing Profile.
 Abort.
 
 Require Import Omega.
-Goal forall n m , n + m + n <= n + m + n + m. 
-intros. time "omega" omega. 
-Print Timing Profile. 
-Qed. 
+Goal forall n m , n + m + n <= n + m + n + m.
+intros. time "omega" omega.
+Print Timing Profile.
+Qed.
+
+Axiom natprod : nat -> nat -> nat.
+Fixpoint twos (k : nat) (x : nat) :=
+  match k with
+    | 0 => x
+    | S k' => twos k' (natprod x x)
+  end.
+
+Axiom x : nat.
+
+Local Notation big := (_ = _).
+
+Goal let k := 17 in twos k x = twos k x.
+Proof.
+  cbv zeta; simpl twos.
+  Fail poor_mans_timeout 1 apply f_equal.
+Admitted.


### PR DESCRIPTION
It runs a tactic, and then later fails if the tactic took too long.

There seems to be a lot of churn because my emacs removes trailing spaces.  I can go back and fix that, if you want.

I'm also not at all sure that this is a particularly good way to do things, but it seems to work.
